### PR TITLE
Don't close popup when drag ends outside popup

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -33,6 +33,7 @@ angular.module('rt.popup', [])
 
                 popup.el.hide().remove();
                 $document.off('click', loseFocus);
+                $document.off('mousedown', checkMouseDown);
             });
         }
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,14 +1,22 @@
 angular.module('rt.popup', [])
     .factory('Popup', function ($window, $document, $timeout, $compile, $parse) {
         var openedPopup = null;
+        var mouseDownInsidePopup = null;
         var template = '<div class="popover"><div ng-include="popupView" onload="$reposition()"></div></div>';
 
         // Padding towards edges of screen.
         var padding = 10;
 
         function loseFocus(e) {
-            if (openedPopup && !$.contains(openedPopup.el[0], e.target)) {
+            if ( (mouseDownInsidePopup === null || mouseDownInsidePopup === false) && openedPopup && !$.contains(openedPopup.el[0], e.target)) {
+                mouseDownInsidePopup = null;
                 hidePopup();
+            }
+        }
+
+        function checkMouseDown(e) {
+            if (openedPopup) {
+                mouseDownInsidePopup = $.contains(openedPopup.el[0], e.target);
             }
         }
 
@@ -174,6 +182,7 @@ angular.module('rt.popup', [])
 
             element.removeClass('hide');
 
+            $document.on('mousedown', checkMouseDown);
             $document.on('click', loseFocus);
 
             $parse(options.popupShown)(scope);


### PR DESCRIPTION
Logic ensures that popup doesn't close when a user does a mousedown inside the popup and the click is registered outside the popup.